### PR TITLE
Add docker-compose for development network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.8'
+
+services:
+  app:
+    image: node:20-alpine
+    working_dir: /app
+    volumes:
+      - .:/app
+    command: npm run dev
+    ports:
+      - "3000:3000"
+    networks:
+      mozaikbzh_app-network:
+        ipv4_address: 172.20.0.20
+    restart: unless-stopped
+    environment:
+      - NODE_ENV=development
+
+networks:
+  mozaikbzh_app-network:
+    external: true


### PR DESCRIPTION
## Summary
- add docker-compose with Node service and external network config

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b6e4592e588322b3c9ddeaae2db8bb