### PR TITLE
Handle missing productsPerPage in pagination

### DIFF
--- a/woonuxt_base/app/components/shopElements/Pagination.test.js
+++ b/woonuxt_base/app/components/shopElements/Pagination.test.js
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+function numberOfPages(length, productsPerPage) {
+  return Math.ceil(length / (productsPerPage || 1));
+}
+
+test('uses full length when productsPerPage is undefined', () => {
+  assert.strictEqual(numberOfPages(7, undefined), 7);
+});
+
+test('uses full length when productsPerPage is 0', () => {
+  assert.strictEqual(numberOfPages(7, 0), 7);
+});

--- a/woonuxt_base/app/components/shopElements/Pagination.vue
+++ b/woonuxt_base/app/components/shopElements/Pagination.vue
@@ -17,7 +17,7 @@ const currentQuery = computed(() => {
 });
 
 const page = ref(route.params.pageNumber ? parseInt(route.params.pageNumber as string) : 1);
-const numberOfPages = computed<number>(() => Math.ceil(products.value.length / productsPerPage || 1));
+const numberOfPages = computed<number>(() => Math.ceil(products.value.length / (productsPerPage || 1)));
 
 const prevSrc = (pageNumber: number) => {
   const target = pageNumber > 1 ? pageNumber - 1 : pageNumber;


### PR DESCRIPTION
## Summary
- fix pagination page count by guarding productsPerPage in the divisor
- add unit test for productsPerPage missing or zero

## Testing
- `node --test woonuxt_base/app/components/shopElements/Pagination.test.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b72683844883228e0fd25b709a0bb7