### PR TITLE
Fetch product category base for breadcrumbs

### DIFF
--- a/woonuxt_base/app/components/generalElements/Breadcrumb.vue
+++ b/woonuxt_base/app/components/generalElements/Breadcrumb.vue
@@ -1,16 +1,13 @@
 <script setup lang="ts">
-const runtimeConfig = useRuntimeConfig();
-
 const { product } = defineProps<{ product: Product }>();
 
-// TODO fetch perma link from WP API
-const productCategoryPermallink = runtimeConfig?.public?.PRODUCT_CATEGORY_PERMALINK || '/product-category/';
+const productCategoryPermalink = await useProductCategoryBase();
 const primaryCategory = computed(() => product.productCategories?.nodes[0]);
 const format = computed(() => [
   { name: 'Products', slug: '/products' },
   {
     name: primaryCategory.value?.name,
-    slug: `${String(productCategoryPermallink)}${primaryCategory.value?.slug}`,
+    slug: `${String(productCategoryPermalink.value)}${primaryCategory.value?.slug}`,
   },
   { name: product.name },
 ]);

--- a/woonuxt_base/app/composables/useProductCategoryBase.ts
+++ b/woonuxt_base/app/composables/useProductCategoryBase.ts
@@ -1,0 +1,24 @@
+import { $fetch } from 'ofetch';
+
+export const useProductCategoryBase = async () => {
+  const runtimeConfig = useRuntimeConfig();
+  const productCategoryBase = useState<string>('productCategoryBase', () => '');
+
+  if (!productCategoryBase.value) {
+    const fallback = runtimeConfig?.public?.PRODUCT_CATEGORY_PERMALINK || '/product-category/';
+    try {
+      const backend = runtimeConfig?.public?.BACKEND_URL;
+      if (backend) {
+        const data: any = await $fetch(`${backend}/wp-json/woonuxt/v1/permalinks`);
+        const permalink = data?.product_category_base || data?.productCategoryBase || data?.permalinks?.product_category_base;
+        productCategoryBase.value = permalink ? `/${String(permalink).replace(/^\/|\/$/g, '')}/` : fallback;
+      } else {
+        productCategoryBase.value = fallback;
+      }
+    } catch {
+      productCategoryBase.value = fallback;
+    }
+  }
+
+  return productCategoryBase;
+};


### PR DESCRIPTION
## Summary
- Fetch product category base path from WordPress REST API and cache the result
- Use fetched permalink when constructing product category breadcrumbs

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: fetch failed to https://mosaik.bzh/graphql/)


------
https://chatgpt.com/codex/tasks/task_e_68b7268cf2788322a7ba9f1f11fc7014