### PR TITLE
fix: streamline initStore reload handling

### DIFF
--- a/woonuxt_base/app/plugins/init.ts
+++ b/woonuxt_base/app/plugins/init.ts
@@ -11,10 +11,7 @@ export default defineNuxtPlugin(async (nuxtApp) => {
 
     async function initStore() {
       if (initialised) {
-        // We only want to execute this code block once, so we return if initialised is truthy and remove the event listeners
-        eventsToFireOn.forEach((event) => {
-          window.removeEventListener(event, initStore);
-        });
+        // We only want to execute this code block once
         return;
       }
 
@@ -40,15 +37,15 @@ export default defineNuxtPlugin(async (nuxtApp) => {
         const reloadCount = useCookie('reloadCount');
         if (!reloadCount.value) {
           reloadCount.value = '1';
+
+          // Log out the user
+          const { logoutUser } = useAuth();
+          await logoutUser();
+
+          window.location.reload();
         } else {
           return;
         }
-
-        // Log out the user
-        const { logoutUser } = useAuth();
-        await logoutUser();
-
-        if (!reloadCount.value) window.location.reload();
       }
     }
 


### PR DESCRIPTION
## Summary
- remove redundant removeEventListener calls in init plugin
- reload only on first missing reloadCount cookie and log out user before reload

## Testing
- `npm run build` *(fails: Failed to load schema from https://mosaik.bzh/graphql/)*
- `npm run dev` *(fails: Failed to load schema from https://mosaik.bzh/graphql/)*

------
https://chatgpt.com/codex/tasks/task_e_68b72a3a0f648322931b5df58ef8d2a6