### PR TITLE
feat: add vendor composables

### DIFF
--- a/woonuxt_base/app/composables/useVendorProducts.ts
+++ b/woonuxt_base/app/composables/useVendorProducts.ts
@@ -1,0 +1,55 @@
+import { $fetch } from 'ofetch';
+
+export const useVendorProducts = () => {
+  const runtimeConfig = useRuntimeConfig();
+
+  const normalizeProduct = (product: any): Product => {
+    const image = product?.images?.[0] || {};
+    return {
+      id: product?.id,
+      databaseId: product?.id,
+      name: product?.name,
+      slug: product?.slug,
+      description: product?.description,
+      shortDescription: product?.short_description,
+      price: product?.price,
+      regularPrice: product?.regular_price,
+      salePrice: product?.sale_price,
+      image: {
+        sourceUrl: image?.src,
+        altText: image?.alt,
+      },
+    } as unknown as Product;
+  };
+
+  async function getVendorProducts(vendorId: number | string): Promise<Product[]> {
+    const { data, error } = await useAsyncData(`vendor-${vendorId}-products`, () =>
+      $fetch<any[]>(`${runtimeConfig.public?.BACKEND_URL}/wp-json/wcfmmp/v1/vendors/${vendorId}/products`),
+    );
+
+    if (error.value) {
+      console.error(error.value);
+      return [];
+    }
+
+    return (data.value || []).map(normalizeProduct);
+  }
+
+  async function getVendorProduct(vendorId: number | string, productId: number | string): Promise<Product | null> {
+    const { data, error } = await useAsyncData(`vendor-${vendorId}-product-${productId}`, () =>
+      $fetch<any>(`${runtimeConfig.public?.BACKEND_URL}/wp-json/wcfmmp/v1/vendors/${vendorId}/products/${productId}`),
+    );
+
+    if (error.value) {
+      console.error(error.value);
+      return null;
+    }
+
+    return data.value ? normalizeProduct(data.value) : null;
+  }
+
+  return {
+    getVendorProducts,
+    getVendorProduct,
+  };
+};

--- a/woonuxt_base/app/composables/useVendors.ts
+++ b/woonuxt_base/app/composables/useVendors.ts
@@ -1,0 +1,56 @@
+import { $fetch } from 'ofetch';
+
+interface Vendor extends Customer {
+  storeName?: string;
+  storeSlug?: string;
+  description?: string;
+  avatarUrl?: string;
+  bannerUrl?: string;
+}
+
+export const useVendors = () => {
+  const runtimeConfig = useRuntimeConfig();
+
+  const normalizeVendor = (vendor: any): Vendor => ({
+    id: vendor?.id ?? vendor?.vendor_id,
+    databaseId: vendor?.id ?? vendor?.vendor_id,
+    email: vendor?.email || '',
+    firstName: vendor?.first_name || '',
+    lastName: vendor?.last_name || '',
+    username: vendor?.store_slug || vendor?.slug || '',
+    avatarUrl: vendor?.avatar || vendor?.gravatar || '',
+    storeName: vendor?.store_name || vendor?.shop_name || '',
+    storeSlug: vendor?.store_slug || vendor?.slug || '',
+    description: vendor?.shop_description || vendor?.description || '',
+    bannerUrl: vendor?.banner || '',
+    billing: {},
+    shipping: {},
+  });
+
+  async function getVendors(): Promise<Vendor[]> {
+    const { data, error } = await useAsyncData('vendors', () => $fetch<any[]>(`${runtimeConfig.public?.BACKEND_URL}/wp-json/wcfmmp/v1/vendors`));
+
+    if (error.value) {
+      console.error(error.value);
+      return [];
+    }
+
+    return (data.value || []).map(normalizeVendor);
+  }
+
+  async function getVendor(id: number | string): Promise<Vendor | null> {
+    const { data, error } = await useAsyncData(`vendor-${id}`, () => $fetch<any>(`${runtimeConfig.public?.BACKEND_URL}/wp-json/wcfmmp/v1/vendors/${id}`));
+
+    if (error.value) {
+      console.error(error.value);
+      return null;
+    }
+
+    return data.value ? normalizeVendor(data.value) : null;
+  }
+
+  return {
+    getVendors,
+    getVendor,
+  };
+};


### PR DESCRIPTION
## Summary
- add `useVendors` composable for fetching and caching vendor data
- add `useVendorProducts` composable to retrieve vendor products with normalization

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b734f1cc9c83229650f1ba9f682e37