### PR TITLE
feat: add vendor storefront and dashboard pages

### DIFF
--- a/woonuxt_base/app/pages/my-account/vendor/index.vue
+++ b/woonuxt_base/app/pages/my-account/vendor/index.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+useSeoMeta({ title: 'Vendor Dashboard' });
+</script>
+
+<template>
+  <div class="container my-8">
+    <h1 class="text-2xl font-semibold mb-4">Vendor Dashboard</h1>
+    <ul class="space-y-2">
+      <li>
+        <NuxtLink to="/my-account/vendor/orders" class="text-primary">Manage Orders</NuxtLink>
+      </li>
+      <li>
+        <NuxtLink to="/my-account/vendor/products" class="text-primary">Manage Products</NuxtLink>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/woonuxt_base/app/pages/my-account/vendor/orders.vue
+++ b/woonuxt_base/app/pages/my-account/vendor/orders.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+useSeoMeta({ title: 'Vendor Orders' });
+</script>
+
+<template>
+  <div class="container my-8">
+    <h1 class="text-2xl font-semibold mb-4">Orders</h1>
+    <p>Manage your store's orders here.</p>
+  </div>
+</template>

--- a/woonuxt_base/app/pages/my-account/vendor/products.vue
+++ b/woonuxt_base/app/pages/my-account/vendor/products.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+useSeoMeta({ title: 'Vendor Products' });
+</script>
+
+<template>
+  <div class="container my-8">
+    <h1 class="text-2xl font-semibold mb-4">Products</h1>
+    <p>Manage your store's products here.</p>
+  </div>
+</template>

--- a/woonuxt_base/app/pages/vendor/[id].vue
+++ b/woonuxt_base/app/pages/vendor/[id].vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+const route = useRoute();
+const { getVendor } = useVendors();
+const { getVendorProducts } = useVendorProducts();
+const { setProducts } = useProducts();
+const id = route.params.id as string;
+
+const vendor = ref<any>(null);
+const isLoading = ref(true);
+
+try {
+  vendor.value = await getVendor(id);
+  const products = await getVendorProducts(id);
+  setProducts(products);
+} finally {
+  isLoading.value = false;
+}
+
+useSeoMeta({
+  title: vendor.value?.storeName ?? 'Vendor',
+  description: vendor.value?.description || '',
+});
+</script>
+
+<template>
+  <div class="container my-8">
+    <div v-if="isLoading" class="flex justify-center py-12">
+      <LoadingIcon />
+    </div>
+    <div v-else-if="vendor">
+      <div class="flex flex-col items-center mb-8 text-center">
+        <img v-if="vendor.avatarUrl" :src="vendor.avatarUrl" :alt="vendor.storeName" class="w-32 h-32 rounded-full mb-4" />
+        <h1 class="text-2xl font-semibold mb-2">{{ vendor.storeName }}</h1>
+        <div v-if="vendor.description" class="max-w-2xl prose" v-html="vendor.description" />
+      </div>
+      <ProductGrid />
+    </div>
+    <div v-else>
+      <p>Vendor not found.</p>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- add vendor storefront page displaying vendor details and product grid
- scaffold vendor dashboard with pages for orders and products management

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68b7439973808322b9e32ddceac09b53